### PR TITLE
enable PAM auth for Hue

### DIFF
--- a/templates/wwbank_template.json
+++ b/templates/wwbank_template.json
@@ -406,6 +406,10 @@
                     "variable": "hue-database_password"
                 },
                 {
+                     "name" : "auth_backend",
+                     "value" : "desktop.auth.backend.PamBackend"
+                },
+                {
                     "name": "database_host",
                     "variable": "hue-database_host"
                 }


### PR DESCRIPTION
                {
                     "name" : "auth_backend",
                     "value" : "desktop.auth.backend.PamBackend"
                },