### PR TITLE
set nifi.cluster.flow.election.max.wait.time=1min

### DIFF
--- a/templates/wwbank_krb_template.json
+++ b/templates/wwbank_krb_template.json
@@ -423,6 +423,10 @@
                 {
                     "refName": "nifi-NIFI_NODE-BASE",
                     "roleType": "NIFI_NODE",
+                    "configs" : [ {
+                       "name" : "nifi.cluster.flow.election.max.wait.time",
+                       "value" : "1 min"
+                     } ],                    
                     "base": true
                 }
             ]


### PR DESCRIPTION
By default NiFi waits 5min to pick up new changes to flow