### PR TITLE
Update wwbank_krb.json

### DIFF
--- a/templates/wwbank_krb.json
+++ b/templates/wwbank_krb.json
@@ -149,8 +149,8 @@
         }
     ],
     "repositories": [
-        "https://archive.cloudera.com/cdh7/7.0/parcels/",
-        "https://archive.cloudera.com/cdh7/{latest_supported}/parcels/"
+            "https://archive.cloudera.com/cdh7/7.0.3.0/parcels/",
+            "https://archive.cloudera.com/cdh7/7.0/parcels/"
     ],
     "services": [
         {


### PR DESCRIPTION
Prior archive repo went to latest which was not going to the trial archive and caused an license install failure as shown in CM log since we are using the trial version.  Updated to just reflect the trial archive location